### PR TITLE
Nim2update

### DIFF
--- a/src/gmp/pure.nim
+++ b/src/gmp/pure.nim
@@ -16,7 +16,7 @@ else:
   const libgmp* = "libgmp.so"
   
 type 
-  mm_gmp_randstate_algdata* {.pure.} = object  {.union.}
+  mm_gmp_randstate_algdata* {.pure, union.} = object
     mp_lc*: pointer
 
   mp_limb_t* = uint

--- a/src/gmp/pure.nim
+++ b/src/gmp/pure.nim
@@ -1495,6 +1495,10 @@ proc mpz_odd_p*(a2: mpz_t): cint =
   (a2.mp_size != 0).cint and (cast[ptr culong](a2.mp_d)[]).cint
 proc mpz_odd_p*(a2: mpz_srcptr): cint = mpz_odd_p(a2[])
 proc mpz_even_p*(a2: mpz_t | mpz_srcptr): cint = (not mpz_odd_p(a2).bool).cint
+proc `=destroy`*(z: var mm_mpz_struct) =
+  mpz_clear(z)
+proc `=destroy`*(z: var mm_mpq_struct) =
+  mpq_clear(z)
 const 
   GMP_ERROR_NONE* = 0
   GMP_ERROR_UNSUPPORTED_ARGUMENT* = 1


### PR DESCRIPTION
I'm updating some code that uses a downstream library bignum.

Changes:
* trivial move of the `union` pragma to the new Nim2 syntax location
* added Nim2 destructors for the underlying MP_INT and MP_RAT types, as the destructors must be in the same module as the type definition.

Checks:
* ran the bigints example through clang address sanitizer - seems okay